### PR TITLE
add support for `wholeDiffableKeys`

### DIFF
--- a/dist/cjs/diff.js
+++ b/dist/cjs/diff.js
@@ -7,7 +7,7 @@ exports.default = void 0;
 
 var _utils = require("./utils.js");
 
-const diff = (lhs, rhs, diffableKeys) => {
+const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
   if (lhs === rhs) return {}; // equal return no diff
 
   if (!(0, _utils.isObject)(lhs) || !(0, _utils.isObject)(rhs)) return rhs; // return updated rhs
@@ -32,14 +32,24 @@ const diff = (lhs, rhs, diffableKeys) => {
     }
 
     if (!(0, _utils.hasOwnProperty)(lhs, key)) {
+      if (wholeDiffableKeys.has(parentKey)) {
+        acc[parentKey] = rhs;
+        return acc;
+      }
+
       acc[key] = rhs[key]; // return added r key
 
       return acc;
     }
 
-    const difference = diff(lhs[key], rhs[key], diffableKeys); // If the difference is empty, and the lhs is an empty object or the rhs is not an empty object
+    const difference = diff(lhs[key], rhs[key], diffableKeys, wholeDiffableKeys, key); // If the difference is empty, and the lhs is an empty object or the rhs is not an empty object
 
     if ((0, _utils.isEmptyObject)(difference) && !(0, _utils.isDate)(difference) && ((0, _utils.isEmptyObject)(lhs[key]) || !(0, _utils.isEmptyObject)(rhs[key]))) return acc; // return no diff
+
+    if (wholeDiffableKeys.has(parentKey)) {
+      acc[parentKey] = rhs;
+      return acc;
+    }
 
     acc[key] = difference; // return updated key
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>): object
+export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey: string): object
 
 export function addedDiff (originalObj: object, updatedObj: object): object
 

--- a/dist/mjs/diff.js
+++ b/dist/mjs/diff.js
@@ -1,6 +1,6 @@
 import { isDate, isEmptyObject, isObject, hasOwnProperty, makeObjectWithoutPrototype } from './utils.js';
 
-const diff = (lhs, rhs, diffableKeys) => {
+const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
   if (lhs === rhs) return {}; // equal return no diff
 
   if (!isObject(lhs) || !isObject(rhs)) return rhs; // return updated rhs
@@ -27,15 +27,24 @@ const diff = (lhs, rhs, diffableKeys) => {
     }
 
     if (!hasOwnProperty(lhs, key)){
+      if (wholeDiffableKeys.has(parentKey)) {
+        acc[parentKey] = rhs;
+        return acc;
+      }
       acc[key] = rhs[key]; // return added r key
       return acc;
-    } 
+    }
 
-    const difference = diff(lhs[key], rhs[key], diffableKeys);
+    const difference = diff(lhs[key], rhs[key], diffableKeys, wholeDiffableKeys, key);
 
     // If the difference is empty, and the lhs is an empty object or the rhs is not an empty object
     if (isEmptyObject(difference) && !isDate(difference) && (isEmptyObject(lhs[key]) || !isEmptyObject(rhs[key])))
       return acc; // return no diff
+
+    if (wholeDiffableKeys.has(parentKey)) {
+      acc[parentKey] = rhs;
+      return acc;
+    }
 
     acc[key] = difference // return updated key
     return acc; // return updated key

--- a/dist/package.json
+++ b/dist/package.json
@@ -6,7 +6,7 @@
   "module": "mjs/index.js",
   "exports": {
     ".": {
-      "import": "./mjs/index.js",
+      "import": "./dist/mjs/index.js",
       "require": "./cjs/index.js",
       "types": "./index.d.ts"
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>): object
+export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey: string): object
 
 export function addedDiff (originalObj: object, updatedObj: object): object
 

--- a/src/diff.js
+++ b/src/diff.js
@@ -43,6 +43,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
 
     if (wholeDiffableKeys.has(parentKey)) {
       console.log("found difference with parent key ", parentKey, " for current key ", key);
+      console.log("acc:", acc);
       acc[parentKey] = rhs;
       return acc;
     }

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,6 +1,6 @@
 import { isDate, isEmptyObject, isObject, hasOwnProperty, makeObjectWithoutPrototype } from './utils.js';
 
-const diff = (lhs, rhs, diffableKeys) => {
+const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
   if (lhs === rhs) return {}; // equal return no diff
 
   if (!isObject(lhs) || !isObject(rhs)) return rhs; // return updated rhs
@@ -27,15 +27,24 @@ const diff = (lhs, rhs, diffableKeys) => {
     }
 
     if (!hasOwnProperty(lhs, key)){
+      if (wholeDiffableKeys.has(parentKey)) {
+        acc[parentKey] = rhs;
+        return acc;
+      }
       acc[key] = rhs[key]; // return added r key
       return acc;
-    } 
+    }
 
-    const difference = diff(lhs[key], rhs[key], diffableKeys);
+    const difference = diff(lhs[key], rhs[key], diffableKeys, wholeDiffableKeys, key);
 
     // If the difference is empty, and the lhs is an empty object or the rhs is not an empty object
     if (isEmptyObject(difference) && !isDate(difference) && (isEmptyObject(lhs[key]) || !isEmptyObject(rhs[key])))
       return acc; // return no diff
+
+    if (wholeDiffableKeys.has(parentKey)) {
+      acc[parentKey] = rhs;
+      return acc;
+    }
 
     acc[key] = difference // return updated key
     return acc; // return updated key

--- a/src/diff.js
+++ b/src/diff.js
@@ -42,6 +42,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
       return acc; // return no diff
 
     if (wholeDiffableKeys.has(parentKey)) {
+      console.log("found difference with parent key ", parentKey, " for current key ", key);
       acc[parentKey] = rhs;
       return acc;
     }

--- a/src/diff.js
+++ b/src/diff.js
@@ -43,9 +43,10 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
 
     if (wholeDiffableKeys.has(parentKey)) {
       console.log("found difference with parent key ", parentKey, " for current key ", key);
-      console.log("acc:", acc);
-      acc[parentKey] = rhs;
-      return acc;
+      // console.log("acc:", acc);
+      // acc[parentKey] = rhs;
+      return rhs;
+      // return acc;
     }
 
     acc[key] = difference // return updated key

--- a/src/diff.js
+++ b/src/diff.js
@@ -28,8 +28,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
 
     if (!hasOwnProperty(lhs, key)){
       if (wholeDiffableKeys.has(parentKey)) {
-        acc[parentKey] = rhs;
-        return acc;
+        return rhs;
       }
       acc[key] = rhs[key]; // return added r key
       return acc;
@@ -42,11 +41,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
       return acc; // return no diff
 
     if (wholeDiffableKeys.has(parentKey)) {
-      console.log("found difference with parent key ", parentKey, " for current key ", key);
-      // console.log("acc:", acc);
-      // acc[parentKey] = rhs;
       return rhs;
-      // return acc;
     }
 
     acc[key] = difference // return updated key


### PR DESCRIPTION
add support for returning the whole object if any of its keys are different.

e.g.  if `car` is in `wholeDiffableKeys` set, for these two cars, even though their makes are the same, because the `model`s are different, the whole `car` object will be returned in the diff tree
```
const car1 = {'car': {'make': 'audi', 'model': 'a1'}};
const car2 = {'car': {'make': 'audi', 'model': 'a3'}};
```
