### PR TITLE
Fixes wholeDiffableKeys

### DIFF
--- a/dist/cjs/diff.js
+++ b/dist/cjs/diff.js
@@ -33,8 +33,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
 
     if (!(0, _utils.hasOwnProperty)(lhs, key)) {
       if (wholeDiffableKeys.has(parentKey)) {
-        acc[parentKey] = rhs;
-        return acc;
+        return rhs;
       }
 
       acc[key] = rhs[key]; // return added r key
@@ -47,8 +46,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
     if ((0, _utils.isEmptyObject)(difference) && !(0, _utils.isDate)(difference) && ((0, _utils.isEmptyObject)(lhs[key]) || !(0, _utils.isEmptyObject)(rhs[key]))) return acc; // return no diff
 
     if (wholeDiffableKeys.has(parentKey)) {
-      acc[parentKey] = rhs;
-      return acc;
+      return rhs;
     }
 
     acc[key] = difference; // return updated key

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey: string): object
+export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey?: string): object
 
 export function addedDiff (originalObj: object, updatedObj: object): object
 

--- a/dist/mjs/diff.js
+++ b/dist/mjs/diff.js
@@ -28,8 +28,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
 
     if (!hasOwnProperty(lhs, key)){
       if (wholeDiffableKeys.has(parentKey)) {
-        acc[parentKey] = rhs;
-        return acc;
+        return rhs;
       }
       acc[key] = rhs[key]; // return added r key
       return acc;
@@ -42,8 +41,7 @@ const diff = (lhs, rhs, diffableKeys, wholeDiffableKeys, parentKey) => {
       return acc; // return no diff
 
     if (wholeDiffableKeys.has(parentKey)) {
-      acc[parentKey] = rhs;
-      return acc;
+      return rhs;
     }
 
     acc[key] = difference // return updated key

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey: string): object
+export function diff (originalObj: object, updatedObj: object, diffableKeys?: Set<string>, wholeDiffableKeys?: Set<string>, parentKey?: string): object
 
 export function addedDiff (originalObj: object, updatedObj: object): object
 


### PR DESCRIPTION
* Make `parentKey` optional. Can't have a required param after an optional param
* Fixes diffing behavior - previously it was nesting results within the parent tree